### PR TITLE
fix: Fix missing link in FAQ for question 'Do you have a self-hosted option?'

### DIFF
--- a/src/content/docs/faq.md
+++ b/src/content/docs/faq.md
@@ -26,7 +26,7 @@ For a full list of our supported models and their functionality, check our [docs
 Yes! We already support VS Code and JetBrains. We have plans to support even more IDEs. If you want to contribute to our new plugins, please reach us out in Discord.
 
 ### Do you have a self-hosted option? 
-Yes. Refact has a free self-hosted version that you can check here. 
+Yes. Refact has a free self-hosted version that you can check [here](https://docs.refact.ai/guides/self-hosted/).
 
 ### Is it possible to fine-tune Refact to the company codebase? 
 Yes. Fine-tuning is currently supported in our free self-hosted and Enterprise plans. 


### PR DESCRIPTION
fix https://github.com/smallcloudai/refact/issues/383

Fixed the missing link by linking to the docs section about Self-Hosted: https://docs.refact.ai/guides/self-hosted/

Let me know if you would rather have that linked to the GitHub repository you link on the Pricing page: https://github.com/smallcloudai/refact